### PR TITLE
Adjusted how parsed xcactivitylog file is saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ In case `--derived-data-path` is specified instead of `--xcodebuild-log-path`, t
 [
   {
     "symbol" : "instance method increase(_:count:file:line:)",
-    "duration" : 2.119999885559082,
+    "ms" : 2.119999885559082,
     "location" : "/MyProject/Counter.swift:192:17"
   },
   {
     "symbol" : "instance method perform(_:)",
-    "duration" : 0.55000001192092896,
+    "ms" : 0.55000001192092896,
     "location" : "/MyProject/Counter.swift:115:17"
   },
   ...

--- a/Sources/SwiftCompilationTimingParserFramework/ParsedTiming.swift
+++ b/Sources/SwiftCompilationTimingParserFramework/ParsedTiming.swift
@@ -25,12 +25,12 @@
 import Foundation
 
 open class ParsedTiming: Codable {
-    public let duration: Float
+    public let ms: Float
     public let location: String
     public let symbol: String
 
-    public init(duration: Float, location: String, symbol: String) {
-        self.duration = duration
+    public init(ms: Float, location: String, symbol: String) {
+        self.ms = ms
         self.location = location
         self.symbol = symbol
     }

--- a/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
+++ b/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
@@ -132,7 +132,15 @@ public class SwiftCompilationTimingParser {
     private func saveActivityLogIfNeeded(_ activityLog: XCLogParser.IDEActivityLog) throws {
         guard let xcactivityLogOutputPath = configuration.xcactivityLogOutputPath else { return }
         let output = XCLogParser.FileOutput(path: xcactivityLogOutputPath)
-        try output.write(report: activityLog)
+        let logReporter = JsonReporter()
+        let buildParser = ParserBuildSteps(
+            machineName: nil,
+            omitWarningsDetails: false,
+            omitNotesDetails: true,
+            truncLargeIssues: false
+        )
+        let buildSteps = try buildParser.parse(activityLog: activityLog)
+        try logReporter.report(build: buildSteps, output: output, rootOutput: "")
     }
 
     private func processRawLog(log: Data) throws -> [ParsedTiming] {

--- a/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
+++ b/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
@@ -233,9 +233,9 @@ private extension Regex where Output == (Substring, Substring, Substring, Substr
         var parsed: [ParsedTiming] = []
         for line in text {
             guard let match = try wholeMatch(in: line) else { continue }
-            guard let duration = Float(match.1), duration >= threshold else { continue }
+            guard let ms = Float(match.1), ms >= threshold else { continue }
 
-            parsed.append(ParsedTiming(duration: duration, location: String(match.2), symbol: String(match.3)))
+            parsed.append(ParsedTiming(ms: ms, location: String(match.2), symbol: String(match.3)))
         }
         return parsed.isEmpty ? nil : parsed
     }
@@ -248,11 +248,10 @@ private extension Array where Element == ParsedTiming {
             var toAdd = timing
             let key = timing.location + timing.symbol
             if let existing = groups[key] {
-                toAdd = ParsedTiming(duration: existing.duration + timing.duration, location: timing.location, symbol: timing.symbol)
+                toAdd = ParsedTiming(ms: existing.ms + timing.ms, location: timing.location, symbol: timing.symbol)
             }
             groups[key] = toAdd
         }
         self = Array(groups.values)
     }
 }
-


### PR DESCRIPTION
## Context

To align `saveActivityLogIfNeeded` function with `xclogparser parse --file <#file#> --reporter json --output <#output#> --omit_notes`, parsed `xcactivitylog` file needs to be processed using `ParserBuildSteps` and the result would be the same as with the given command.