### PR TITLE
Add pretty output formatting

### DIFF
--- a/Sources/SwiftCompilationTimingParser/SwiftCompilationTimingParser.swift
+++ b/Sources/SwiftCompilationTimingParser/SwiftCompilationTimingParser.swift
@@ -39,6 +39,7 @@ struct SwiftCompilationTimingParser: AsyncParsableCommand {
         case xcactivityLogOutputPath
         case xcodebuildLogPath
         case shouldEnableGrouping
+        case prettyOutputFormating
     }
 
     @Option(name: .customLong("root-path"), help: "Absolute path to the project's root folder. Used for filtering purpose to cut out the username and other non-relevant paths when logs are parsed")
@@ -71,8 +72,11 @@ struct SwiftCompilationTimingParser: AsyncParsableCommand {
     @Flag(name: .customLong("enable-grouping"), help: "(Optional) If specified, symbols are grouped by location and symbol before being written to `--output-path`")
     var shouldEnableGrouping = false
 
+    @Flag(name: .customLong("pretty-output"), help: "(Optional) If specified, the output JSON will be formatted with indentation and line breaks for improved readability")
+    var prettyOutputFormating = false
+    
     func run() async throws {
-        let configuration = SwiftCompilationTimingParserFramework.SwiftCompilationTimingParser.Configuration(xcactivityLogOutputPath: xcactivityLogOutputPath, outputPath: outputPath, threshold: threshold, targetName: targetName, filteredPath: filteredPath, xcodebuildLogPath: xcodebuildLogPath, derivedDataPath: derivedDataPath, rootPath: rootPath)
+        let configuration = SwiftCompilationTimingParserFramework.SwiftCompilationTimingParser.Configuration(xcactivityLogOutputPath: xcactivityLogOutputPath, outputPath: outputPath, threshold: threshold, targetName: targetName, filteredPath: filteredPath, xcodebuildLogPath: xcodebuildLogPath, derivedDataPath: derivedDataPath, rootPath: rootPath, prettyOutputFormating: prettyOutputFormating)
         try await SwiftCompilationTimingParserFramework.SwiftCompilationTimingParser(configuration: configuration).run()
     }
 }

--- a/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
+++ b/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
@@ -52,8 +52,9 @@ public class SwiftCompilationTimingParser {
         let xcodebuildLogPath: String?
         let derivedDataPath: String?
         let rootPath: String
+        let prettyOutputFormating: Bool
 
-        public init(xcactivityLogOutputPath: String? = nil, outputPath: String, threshold: Float, targetName: String, filteredPath: String? = nil, xcodebuildLogPath: String? = nil, derivedDataPath: String? = nil, rootPath: String) {
+        public init(xcactivityLogOutputPath: String? = nil, outputPath: String, threshold: Float, targetName: String, filteredPath: String? = nil, xcodebuildLogPath: String? = nil, derivedDataPath: String? = nil, rootPath: String, prettyOutputFormating: Bool) {
             self.xcactivityLogOutputPath = xcactivityLogOutputPath
             self.outputPath = outputPath
             self.threshold = threshold
@@ -62,6 +63,7 @@ public class SwiftCompilationTimingParser {
             self.xcodebuildLogPath = xcodebuildLogPath
             self.derivedDataPath = derivedDataPath
             self.rootPath = rootPath
+            self.prettyOutputFormating = prettyOutputFormating
         }
     }
 
@@ -125,6 +127,9 @@ public class SwiftCompilationTimingParser {
 
     private func saveFiles(parsedTimings: [ParsedTiming]) throws {
         let jsonEncoder = JSONEncoder()
+        if configuration.prettyOutputFormating {
+            jsonEncoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
+        }
         let data = try jsonEncoder.encode(parsedTimings)
         try data.write(to: URL(filePath: configuration.outputPath))
     }

--- a/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
+++ b/Sources/SwiftCompilationTimingParserFramework/SwiftCompilationTimingParser.swift
@@ -128,7 +128,7 @@ public class SwiftCompilationTimingParser {
     private func saveFiles(parsedTimings: [ParsedTiming]) throws {
         let jsonEncoder = JSONEncoder()
         if configuration.prettyOutputFormating {
-            jsonEncoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
+            jsonEncoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes, .sortedKeys]
         }
         let data = try jsonEncoder.encode(parsedTimings)
         try data.write(to: URL(filePath: configuration.outputPath))


### PR DESCRIPTION
Hi!
I added an optional option `--pretty-output` for improving the output file readability. 

Before:
```
[{"location":"\/Sources\/ComposableCoreLocation\/Models\/Location.swift:39:22","symbol":"operator function ==(_:_:)","ms":118.65},{"ms":114.45,"location":"\/Sources\/ComposableCoreLocation\/Models\/Location.swift:39:22","symbol":"operator function ==(_:_:)"}]
```

After:
```
[
  {
    "location" : "/Sources/ComposableCoreLocation/Models/Location.swift:39:22",
    "ms" : 118.65,
    "symbol" : "operator function ==(_:_:)"
  },
  {
    "location" : "/Sources/ComposableCoreLocation/Models/Location.swift:39:22",
    "ms" : 114.45,
    "symbol" : "operator function ==(_:_:)"
  }
]
```